### PR TITLE
Add audio setup for Neural DSP guitar rig

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,4 +91,21 @@ cp -r ~/.config/ghostty ~/.config/ghostty_old 2>/dev/null
 rm -rf ~/.config/ghostty
 ln -fs "$PWD/ghostty" ~/.config/ghostty
 
+# PipeWire low-latency config
+mkdir -p ~/.config/pipewire/pipewire.conf.d
+ln -fs "$PWD/pipewire/pipewire.conf.d/99-low-latency.conf" ~/.config/pipewire/pipewire.conf.d/99-low-latency.conf
+
+# WirePlumber ALSA tuning (Scarlett Solo)
+mkdir -p ~/.config/wireplumber/main.lua.d
+ln -fs "$PWD/wireplumber/main.lua.d/51-scarlett-low-latency.lua" ~/.config/wireplumber/main.lua.d/51-scarlett-low-latency.lua
+
+# Yabridge config
+mkdir -p ~/.config/yabridge
+ln -fs "$PWD/yabridge/yabridge.toml" ~/.config/yabridge/yabridge.toml
+
+# Scripts
+mkdir -p ~/scripts
+ln -fs "$PWD/scripts/guitar-session.sh" ~/scripts/guitar-session.sh
+ln -fs "$PWD/scripts/setup-neuraldsp.sh" ~/scripts/setup-neuraldsp.sh
+
 echo "All Done."

--- a/pipewire/pipewire.conf.d/99-low-latency.conf
+++ b/pipewire/pipewire.conf.d/99-low-latency.conf
@@ -1,0 +1,14 @@
+# Low-latency configuration for guitar practice with Neural DSP
+# Quantum 512 @ 48000 = ~10.7ms (stable with Scarlett Solo USB + Wine/yabridge)
+# Rate locked to 48000 to avoid resampling (Bluetooth needs 48k, Spotify is resampled transparently)
+#
+# To adjust: change default.clock.quantum and restart PipeWire:
+#   systemctl --user restart pipewire pipewire-pulse wireplumber
+
+context.properties = {
+    default.clock.rate          = 48000
+    default.clock.allowed-rates = [ 48000 ]
+    default.clock.quantum       = 512
+    default.clock.min-quantum   = 32
+    default.clock.max-quantum   = 8192
+}

--- a/scripts/guitar-session.sh
+++ b/scripts/guitar-session.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# guitar-session.sh — Start a low-latency guitar practice session
+# with Neural DSP plugins in REAPER via PipeWire JACK
+#
+# Usage:
+#   guitar-session.sh              Launch REAPER (default)
+#   guitar-session.sh standalone   Launch Nolly standalone (requires Wine 11.x)
+#   guitar-session.sh standalone petrucci  Launch Petrucci standalone
+#
+
+set -euo pipefail
+
+REAPER_BIN="$HOME/opt/REAPER/reaper"
+WINEPREFIX="$HOME/.wine-neuraldsp"
+export WINEPREFIX
+
+NOLLY_EXE="$WINEPREFIX/drive_c/Program Files/Neural DSP/Archetype Nolly X/Archetype Nolly X.exe"
+PETRUCCI_EXE="$WINEPREFIX/drive_c/Program Files/Neural DSP/Archetype Petrucci X/Archetype Petrucci X.exe"
+
+echo "=== Guitar Practice Session ==="
+echo ""
+
+# 1. Verify Scarlett Solo is connected
+if ! pw-cli list-objects Node 2>/dev/null | grep -q "Scarlett Solo"; then
+    echo "ERROR: Scarlett Solo 4th Gen not detected!"
+    echo "  - Check USB connection"
+    echo "  - Run: pw-cli list-objects Node | grep Scarlett"
+    exit 1
+fi
+echo "[OK] Scarlett Solo 4th Gen detected"
+
+# 2. Set CPU governor to performance (reduces latency spikes from frequency scaling)
+if [ -w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ]; then
+    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor > /dev/null 2>&1
+    echo "[OK] CPU governor: performance"
+elif command -v cpupower &>/dev/null; then
+    sudo cpupower frequency-set -g performance > /dev/null 2>&1 && echo "[OK] CPU governor: performance" || echo "[!!] Could not set CPU governor (needs sudo)"
+else
+    echo "[!!] CPU governor unchanged (install cpupower or run as root)"
+fi
+
+# 4. Verify PipeWire quantum
+QUANTUM=$(pw-metadata -n settings 0 2>/dev/null | grep "key:'clock.quantum'" | grep -oP "value:'\K[0-9]+" || echo "default")
+echo "[OK] PipeWire quantum: ${QUANTUM} samples at 48000Hz"
+
+# 5. Set Scarlett as default audio device
+SCARLETT_SINK=$(pw-cli list-objects Node 2>/dev/null | grep -B5 "Scarlett Solo" | grep -B5 "Audio/Sink" | grep -oP 'id \K[0-9]+' | head -1 || true)
+SCARLETT_SOURCE=$(pw-cli list-objects Node 2>/dev/null | grep -B5 "Scarlett Solo" | grep -B5 "Audio/Source" | grep -oP 'id \K[0-9]+' | head -1 || true)
+
+[ -n "$SCARLETT_SINK" ] && wpctl set-default "$SCARLETT_SINK" 2>/dev/null || true
+[ -n "$SCARLETT_SOURCE" ] && wpctl set-default "$SCARLETT_SOURCE" 2>/dev/null || true
+echo "[OK] Scarlett Solo set as default input/output"
+
+echo ""
+echo "=== Scarlett Solo Routing Reminder ==="
+echo "  Input 1 (XLR/TTS): Guitar (use INST mode on the Scarlett)"
+echo "  Output:             Headphones or monitors"
+echo "======================================="
+echo ""
+
+if [ "${1:-}" = "standalone" ]; then
+    PLUGIN="${2:-nolly}"
+    if [ "$PLUGIN" = "petrucci" ] || [ "$PLUGIN" = "p" ]; then
+        echo "[..] Launching Archetype Petrucci X (standalone)..."
+        wine explorer /desktop=NeuralDSP,1920x1080 "$PETRUCCI_EXE" > /dev/null 2>&1 &
+    else
+        echo "[..] Launching Archetype Nolly X (standalone)..."
+        wine explorer /desktop=NeuralDSP,1920x1080 "$NOLLY_EXE" > /dev/null 2>&1 &
+    fi
+    disown
+    echo "  Audio driver: Windows Audio (WASAPI)"
+else
+    echo "[..] Launching REAPER (via pw-jack)..."
+    echo "  Audio system: JACK"
+    echo "  Add FX -> VST3 -> Neural DSP -> Archetype Nolly/Petrucci"
+    pw-jack "$REAPER_BIN" > /dev/null 2>&1 &
+    disown
+fi
+
+echo ""
+echo "Happy playing!"

--- a/scripts/setup-neuraldsp.sh
+++ b/scripts/setup-neuraldsp.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# setup-neuraldsp.sh — Install Wine, yabridge, and configure the system
+# for Neural DSP Archetype plugins on Ubuntu 24.04
+#
+# Usage: ./setup-neuraldsp.sh
+# Requires: sudo access, internet connection
+#
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[OK]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!!]${NC} $*"; }
+err()  { echo -e "${RED}[ERR]${NC} $*"; }
+step() { echo -e "\n${YELLOW}=== $* ===${NC}"; }
+
+WINEPREFIX="$HOME/.wine-neuraldsp"
+YABRIDGE_DIR="$HOME/.local/share/yabridge"
+LOCAL_BIN="$HOME/.local/bin"
+
+# ─── Step 1: Install wine-staging ───────────────────────────────────────────
+
+step "Step 1: Installing wine-staging"
+
+sudo dpkg --add-architecture i386
+log "Enabled i386 architecture"
+
+sudo mkdir -pm755 /etc/apt/keyrings
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+log "Added WineHQ signing key"
+
+# Check if Noble sources exist, add if not
+if [ ! -f /etc/apt/sources.list.d/winehq-noble.sources ]; then
+    sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources
+    log "Added WineHQ Noble repository"
+else
+    log "WineHQ Noble repository already configured"
+fi
+
+sudo apt update
+sudo apt install --install-recommends -y winehq-staging
+log "wine-staging installed: $(wine --version)"
+
+# Install winetricks
+if ! command -v winetricks &>/dev/null; then
+    sudo apt install -y winetricks
+    log "winetricks installed"
+else
+    log "winetricks already installed"
+fi
+
+# ─── Step 2: Configure Wine prefix ─────────────────────────────────────────
+
+step "Step 2: Configuring Wine prefix at $WINEPREFIX"
+
+export WINEPREFIX
+export WINEARCH=win64
+
+if [ ! -d "$WINEPREFIX" ]; then
+    wineboot --init
+    log "Created win64 prefix"
+else
+    log "Wine prefix already exists"
+fi
+
+# Install required components
+winetricks -q vcrun2019
+log "Installed vcrun2019 (Visual C++ runtime)"
+
+winetricks -q corefonts
+log "Installed corefonts"
+
+winetricks -q d3dcompiler_47
+log "Installed d3dcompiler_47 (DirectX shader compiler)"
+
+winetricks -q gdiplus
+log "Installed gdiplus"
+
+winetricks win10
+log "Set Windows version to Windows 10"
+
+# ─── Step 3: Install yabridge ──────────────────────────────────────────────
+
+step "Step 3: Installing yabridge + yabridgectl"
+
+mkdir -p "$YABRIDGE_DIR" "$LOCAL_BIN"
+
+YABRIDGE_VERSION=$(curl -s https://api.github.com/repos/robbert-vdh/yabridge/releases/latest | grep -Po '"tag_name": "\K[^"]*')
+
+if [ -z "$YABRIDGE_VERSION" ]; then
+    err "Failed to fetch latest yabridge version from GitHub API"
+    err "Check your internet connection or try again later"
+    exit 1
+fi
+
+log "Latest yabridge version: $YABRIDGE_VERSION"
+
+cd /tmp
+
+# Download yabridge (yabridgectl is bundled inside the same tarball)
+if [ ! -f "yabridge-${YABRIDGE_VERSION}.tar.gz" ]; then
+    wget "https://github.com/robbert-vdh/yabridge/releases/download/${YABRIDGE_VERSION}/yabridge-${YABRIDGE_VERSION}.tar.gz"
+fi
+
+# Extract all yabridge files
+tar -xzf "yabridge-${YABRIDGE_VERSION}.tar.gz" -C "$YABRIDGE_DIR" --strip-components=1
+log "Extracted yabridge to $YABRIDGE_DIR"
+
+# Copy yabridgectl to ~/.local/bin
+cp "$YABRIDGE_DIR/yabridgectl" "$LOCAL_BIN/yabridgectl"
+chmod +x "$LOCAL_BIN/yabridgectl"
+log "Installed yabridgectl to $LOCAL_BIN"
+
+# Ensure ~/.local/bin is in PATH for this session
+export PATH="$LOCAL_BIN:$PATH"
+
+# Configure yabridgectl (auto-detects ~/.local/share/yabridge, no set --path needed)
+mkdir -p "$WINEPREFIX/drive_c/Program Files/Common Files/VST3"
+yabridgectl add "$WINEPREFIX/drive_c/Program Files/Common Files/VST3"
+log "Added Neural DSP VST3 directory to yabridge"
+
+log "yabridgectl version: $(yabridgectl --version)"
+
+# ─── Step 4: Verify ────────────────────────────────────────────────────────
+
+step "Step 4: Verification"
+
+echo "  Wine:        $(wine --version)"
+echo "  Winetricks:  $(winetricks --version 2>&1 | head -1)"
+echo "  yabridgectl: $(yabridgectl --version)"
+echo "  Prefix:      $WINEPREFIX"
+echo "  Prefix arch: win64"
+
+# ─── Step 5: PATH reminder ─────────────────────────────────────────────────
+
+step "Step 5: PATH check"
+
+if ! grep -q '\.local/bin' ~/.zshrc 2>/dev/null; then
+    warn "~/.local/bin is NOT in your zshrc PATH"
+    warn "Add this line to your ~/.zshrc (or run the dotfiles install):"
+    echo '  export PATH="$HOME/.local/bin:$PATH"'
+else
+    log "~/.local/bin already in zshrc PATH"
+fi
+
+# ─── Done ───────────────────────────────────────────────────────────────────
+
+step "Setup complete!"
+echo ""
+echo "Next steps (manual):"
+echo "  1. Install Neural DSP plugins — see instructions printed by guitar-session setup"
+echo "  2. Activate licenses inside Wine (GUI)"
+echo "  3. Run: yabridgectl sync"
+echo "  4. Add ~/.vst3/yabridge to REAPER's VST scan paths"
+echo ""

--- a/wireplumber/main.lua.d/51-scarlett-low-latency.lua
+++ b/wireplumber/main.lua.d/51-scarlett-low-latency.lua
@@ -1,0 +1,20 @@
+-- Low-latency ALSA config for Focusrite Scarlett Solo 4th Gen
+alsa_monitor.rules = {
+  {
+    matches = {
+      {
+        { "node.name", "matches", "alsa_output.*Scarlett*" },
+      },
+      {
+        { "node.name", "matches", "alsa_input.*Scarlett*" },
+      },
+    },
+    apply_properties = {
+      ["api.alsa.disable-batch"] = true,
+      ["api.alsa.headroom"]      = 128,
+      ["api.alsa.period-size"]   = 512,
+      ["api.alsa.period-num"]    = 2,
+      ["session.suspend-timeout-seconds"] = 0,
+    },
+  },
+}

--- a/yabridge/yabridge.toml
+++ b/yabridge/yabridge.toml
@@ -1,0 +1,8 @@
+# yabridge configuration for Neural DSP plugins in REAPER
+# https://github.com/robbert-vdh/yabridge#configuration
+
+["Archetype Nolly X.vst3"]
+editor_force_dnd = true
+
+["Archetype Petrucci X.vst3"]
+editor_force_dnd = true


### PR DESCRIPTION
## Summary
- PipeWire low-latency config (512 quantum @ 48kHz) for Scarlett Solo USB
- WirePlumber ALSA tuning for Focusrite Scarlett Solo 4th Gen
- Yabridge config for Neural DSP Archetype plugins (Nolly X, Petrucci X)
- `guitar-session.sh` — launch REAPER or standalone plugins via PipeWire JACK
- `setup-neuraldsp.sh` — full install script for Wine, yabridge, and dependencies
- Symlinks added to `install.sh`