### PR TITLE
Fix neovim install in install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ All configs are symlinked from this repository to home directory:
 ~/workspace/dotfiles/gitconfig        → ~/.gitconfig
 ~/workspace/dotfiles/tmux.conf        → ~/.tmux.conf
 ~/workspace/dotfiles/zshrc            → ~/.zshrc
-~/workspace/dotfiles/nvchad/          → ~/.config/nvim (default)
+~/workspace/dotfiles/lazyvim/         → ~/.config/nvim (default)
 ~/workspace/dotfiles/ghostty/         → ~/.config/ghostty
 ~/workspace/dotfiles/pipewire/...     → ~/.config/pipewire/...
 ~/workspace/dotfiles/wireplumber/...  → ~/.config/wireplumber/...

--- a/install.sh
+++ b/install.sh
@@ -47,13 +47,9 @@ pyenv install 3.12
 pyenv global 3.12
 pip install s3cmd kubernetes
 
-# neovim dependencies
-# fd ?
+# neovim (latest stable) + dependencies
+sudo snap install nvim --classic
 sudo apt install ripgrep fd
-
-# install lazyman
-git clone https://github.com/doctorfree/nvim-lazyman $HOME/.config/nvim-Lazyman
-$HOME/.config/nvim-Lazyman/lazyman.sh
 
 # k9s
 wget https://github.com/derailed/k9s/releases/download/v0.31.9/k9s_linux_amd64.deb && dpkg -i k9s_linux_amd64.deb
@@ -82,7 +78,8 @@ ln -fs "$PWD/gitconfig" ~/.gitconfig
 ln -fs "$PWD/gitignore" ~/.gitignore
 ln -fs "$PWD/tmux.conf" ~/.tmux.conf
 ln -fs "$PWD/zshrc" ~/.zshrc
-ln -fs "$PWD/nvim" ~/.config/nvim
+mkdir -p ~/.config
+ln -fs "$PWD/lazyvim" ~/.config/nvim   # default config; switch with `nvchad`/`lazyvim` aliases
 ln -fs "$PWD/zshrc_imi" ~/.zshrc_imi
 
 # Ghostty


### PR DESCRIPTION
## Summary

The repo's `install.sh` never actually installed the Neovim binary, and its config symlink was broken. This was leftover from the `nvim/` → `nvchad/` rename + dual-config switch (commit e1ec0eb) that left the installer half-updated.

## Changes

- **Install the binary**: replaced the orphaned Lazyman block (`git clone doctorfree/nvim-lazyman` + `lazyman.sh`) with `sudo snap install nvim --classic`, matching how Neovim is actually installed on the machine (snap, `latest/stable`). No prior version of `install.sh` ever installed the `nvim` binary directly.
- **Fix the default symlink**: `~/.config/nvim` now points at `lazyvim/` (the current default) instead of the nonexistent `$PWD/nvim`, which produced a dangling symlink on a fresh install. Added `mkdir -p ~/.config` for safety.
- **README consistency**: symlink table now lists `lazyvim/` as the default config.

Switching between configs is still handled by the `nvchad` / `lazyvim` zshrc aliases.

## Test plan

- `install.sh` symlink target (`lazyvim/`) exists in the repo.
- `snap install nvim --classic` matches the verified install (`/snap/bin/nvim`, NVIM v0.12.2, `neovim-snap` / `classic`).